### PR TITLE
Clarify README regarding liquid asset manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,16 +59,16 @@ Jekyll Asset Pipeline is extremely easy to add to your Jekyll project and has no
 
   ``` html
   {% css_asset_tag global %}
-  - /_assets/foo.css
-  - /_assets/bar.css
+  - /_assets/foo.scss
+  - /_assets/bar.scss
   {% endcss_asset_tag %}
 
   {% javascript_asset_tag global %}
-  - /_assets/foo.js
-  - /_assets/bar.js
+  - /_assets/foo.coffee
+  - /_assets/bar.coffee
   {% endjavascript_asset_tag %}
   ```
-  > *Asset manifests must be formatted as YAML arrays and include full paths to each asset from the root of the project.*
+  > *Asset manifests must be formatted as YAML arrays and include full paths to each asset from the root of the project. If you are using preprocessing (see the next section), then the paths in the manifest will be your un-preprocessed files (such as *.sass files, or *.coffeescript files), that will then be processed with Jekyll Asset Pipeline.*
 
 5. Run the `jekyll` command to compile your site.  You should see an output that includes the following Jekyll Asset Pipeline status messages.
 


### PR DESCRIPTION
First, thanks for this project. It's great.

With regard to my change, I may be the only person who couldn't figure this out, but I spent a really frustrating hour Googling for an answer to why I kept getting a `Asset Pipeline: Failed to generate hash from provided manifest.` error. In the README, the example files end with `.css` and `.js`, and you link to them in the head of the HTML, so I figured you use the preprocessed extensions before running the `jekyll` command. But obviously, you link to the un-preprocessed files like `.sass`. I edited the filenames and added a brief bit below that part to clarify. 

I think it helps, but if you think it's already obvious, then my feelings won't be hurt if you close this without merging.
## EDIT

I reread the documentation again, and now that I understand what's going on, I guess I can see that this may not be necessary because of this sentence:

> You may notice that your assets have not been converted or compressed-- we will add that functionality next.

But my concern is that when you add the `sass` gem, for example, and then go to preprocess it by running `jekyll`, you will get the asset pipeline error because you no longer want the `.css` file you declared in the manifest, but rather the `.sass` file you're ready to preprocess.

Does it make sense why I'd be confused?
