### PR TITLE
Add dirname to Converter

### DIFF
--- a/lib/jekyll_asset_pipeline/asset.rb
+++ b/lib/jekyll_asset_pipeline/asset.rb
@@ -1,10 +1,11 @@
 module JekyllAssetPipeline
   class Asset
-    def initialize(content, filename)
+    def initialize(content, filename, dirname = '.')
       @content = content
       @filename = filename
+      @dirname = dirname
     end
 
-    attr_accessor :content, :filename, :output_path
+    attr_accessor :content, :filename, :dirname, :output_path
   end
 end

--- a/lib/jekyll_asset_pipeline/converter.rb
+++ b/lib/jekyll_asset_pipeline/converter.rb
@@ -5,6 +5,7 @@ module JekyllAssetPipeline
     def initialize(asset)
       @content = asset.content
       @type = File.extname(asset.filename).downcase
+      @dirname = asset.dirname
       @converted = self.convert
     end
 

--- a/lib/jekyll_asset_pipeline/pipeline.rb
+++ b/lib/jekyll_asset_pipeline/pipeline.rb
@@ -109,8 +109,9 @@ module JekyllAssetPipeline
     def collect
       begin
         @assets = YAML::load(@manifest).map! do |path|
-          File.open(File.join(@source, path)) do |file|
-            JekyllAssetPipeline::Asset.new(file.read, File.basename(path))
+          full_path = File.join(@source, path)
+          File.open(full_path) do |file|
+            JekyllAssetPipeline::Asset.new(file.read, File.basename(path), File.dirname(full_path))
           end
         end
       rescue Exception => e
@@ -186,7 +187,7 @@ module JekyllAssetPipeline
     def gzip
       @assets.map! do |asset|
         gzip_content = Zlib::Deflate.deflate(asset.content)
-        [asset, JekyllAssetPipeline::Asset.new(gzip_content, "#{asset.filename}.gz")]
+        [asset, JekyllAssetPipeline::Asset.new(gzip_content, "#{asset.filename}.gz", asset.dirname)]
       end.flatten!
     end
 

--- a/spec/converter_spec.rb
+++ b/spec/converter_spec.rb
@@ -16,6 +16,7 @@ describe Converter do
       before do
         asset.expect(:content, 'foo')
         asset.expect(:filename, 'bar.baz')
+        asset.expect(:dirname, '.')
       end
 
       subject { Converter.new(asset) }
@@ -51,6 +52,7 @@ describe Converter do
       before do
         asset.expect(:content, 'unconverted')
         asset.expect(:filename, 'some_filename.foo')
+        asset.expect(:dirname, '/some/path')
       end
 
       subject { TestConverter.new(asset) }


### PR DESCRIPTION
It is useful for the Sass converter, as it needs to know the path
to the asset file to process directives like @import. Currently
there is no way for a converter to know where the file come from.

Now the convert method can be as follows:

```
def convert
  return Sass::Engine.new(@content, load_paths: [@dirname], syntax: :scss).render
end
```
