### PR TITLE
Make asset tags accept nested liquid blocks

### DIFF
--- a/lib/jekyll_asset_pipeline/extensions/liquid/liquid_block_extensions.rb
+++ b/lib/jekyll_asset_pipeline/extensions/liquid/liquid_block_extensions.rb
@@ -15,7 +15,9 @@ module JekyllAssetPipeline
       config = site.config['asset_pipeline'] || {}
 
       # Run Jekyll Asset Pipeline
-      pipeline, cached = Pipeline.run(@nodelist.first, @markup.strip, site.source,
+      manifest = render_all(@nodelist, context)
+      return nil if manifest.strip.empty?
+      pipeline, cached = Pipeline.run(manifest, @markup.strip, site.source,
         site.dest, self.class.tag_name, self.class.output_type, config)
 
       if pipeline.is_a?(Pipeline)

--- a/spec/extensions/liquid/liquid_block_extensions_spec.rb
+++ b/spec/extensions/liquid/liquid_block_extensions_spec.rb
@@ -36,6 +36,11 @@ describe LiquidBlockExtensions do
         def self.output_type
           '.baz'
         end
+
+        def render_all(list, context)
+          # it's againt the purpose of render_all; here we're just mocking
+          list.first
+        end
       end
     end
 


### PR DESCRIPTION
For example, the following code will work:

```
{% css_asset_tag global %}
  {% for path in page.stylesheets %}
    - {{ path }}
  {% endfor %}
{% endcss_asset_tag %}
```

I didn't included tests for this, since it seemed hard to write
such tests with the project's current test patterns. I made a small
change to a spec file just to make the current tests not fail.
