### PR TITLE
Loosen dependency on Jekyll to work with newly released version 1.0.0

### DIFF
--- a/jekyll_asset_pipeline.gemspec
+++ b/jekyll_asset_pipeline.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.license                 = 'MIT'
 
   # Runtime dependencies
-  s.add_runtime_dependency 'jekyll', '~> 0.12'
+  s.add_runtime_dependency 'jekyll', '>= 0.12'
   s.add_runtime_dependency 'liquid', '~> 2.4'
 
   # Development dependencies


### PR DESCRIPTION
All tests are passing with Jekyll 0.12 and with Jekyll 1.0.0
