### PR TITLE
Removed newlines from asset templates

### DIFF
--- a/lib/jekyll_asset_pipeline/templates/css_tag_template.rb
+++ b/lib/jekyll_asset_pipeline/templates/css_tag_template.rb
@@ -10,7 +10,7 @@ module JekyllAssetPipeline
     end
 
     def html
-      "<link href='/#{@path}/#{@filename}' rel='stylesheet' type='text/css' />\n"
+      "<link href='/#{@path}/#{@filename}' rel='stylesheet' type='text/css' />"
     end
   end
 end

--- a/lib/jekyll_asset_pipeline/templates/javascript_tag_template.rb
+++ b/lib/jekyll_asset_pipeline/templates/javascript_tag_template.rb
@@ -10,7 +10,7 @@ module JekyllAssetPipeline
     end
 
     def html
-      "<script src='/#{@path}/#{@filename}' type='text/javascript'></script>\n"
+      "<script src='/#{@path}/#{@filename}' type='text/javascript'></script>"
     end
   end
 end


### PR DESCRIPTION
Newlines are not needed here since the Liquid tag will have a newline after it. Previous template breaks javascript variables if the user wants to include the asset tag inside a variable for programmatic inclusion on a specific condition. Seems silly that the user should have to override the templates just for this.
