### PR TITLE
Add a .travis.yml file for builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: ruby
+rvm:
+- 1.9.3
+
+install:
+- bundle install
+- rake test || exit 1


### PR DESCRIPTION
I noticed that Travis Ci was enabled for `jekyll-asset-pipeline`; however, there doesn't seem to be a `.travis.yml` file. I added one which runs rake tests and quits with an error code of 1 if anything fails. Hope this'll help.
